### PR TITLE
Fix delete task endpoint to return 404 if task not found

### DIFF
--- a/controllers/taskControllers.js
+++ b/controllers/taskControllers.js
@@ -95,6 +95,16 @@ exports.updateTask = (req, res) => {
 exports.deleteTask = (req, res) => {
     const tasks = readTasksFromFile();
     const taskId = parseInt(req.url.split('/').pop());
+    const taskIndex = tasks.findIndex(task => task.id === taskId);
+
+    if (taskIndex === -1) {
+        res.writeHead(404, { 'content-type': 'application/json'});
+        res.end(JSON.stringify({
+            message: 'Task not found'
+        }))
+        return;
+    }
+
     const updatedTasks = tasks.filter(task => task.id !== taskId);
     writeTasksToFile(updatedTasks);
     res.writeHead(200, { 'content-type': 'application/json' });


### PR DESCRIPTION
Update the `deleteTask` function to handle the case where the task is not found.

* Check if the task exists before attempting to delete it.
* Return a 404 status code and 'Task not found' message if the task does not exist.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/baabale/taskify?shareId=e48aa0f2-11ba-4f1d-89ff-56e98036e35a).